### PR TITLE
Remove exceptions and add validity flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var Color = function (obj) {
 		return new Color(obj);
 	}
 
+	this.valid = false;
 	this.values = {
 		rgb: [0, 0, 0],
 		hsl: [0, 0, 0],
@@ -29,8 +30,6 @@ var Color = function (obj) {
 			this.setValues('hsl', vals);
 		} else if (vals = string.getHwb(obj)) {
 			this.setValues('hwb', vals);
-		} else {
-			throw new Error('Unable to parse color from string "' + obj + '"');
 		}
 	} else if (typeof obj === 'object') {
 		vals = obj;
@@ -44,13 +43,14 @@ var Color = function (obj) {
 			this.setValues('hwb', vals);
 		} else if (vals.c !== undefined || vals.cyan !== undefined) {
 			this.setValues('cmyk', vals);
-		} else {
-			throw new Error('Unable to parse color from object ' + JSON.stringify(obj));
 		}
 	}
 };
 
 Color.prototype = {
+	isValid: function () {
+		return this.valid;
+	},
 	rgb: function () {
 		return this.setSpace('rgb', arguments);
 	},
@@ -393,6 +393,8 @@ Color.prototype.setValues = function (space, vals) {
 	var maxes = this.maxes;
 	var alpha = 1;
 	var i;
+
+	this.valid = true;
 
 	if (space === 'alpha') {
 		alpha = vals;

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,6 @@ var equal = assert.equal;
 var ok = assert.ok;
 var strictEqual = assert.strictEqual;
 var notStrictEqual = assert.notStrictEqual;
-var throws = assert.throws;
 
 it('Color() instance', function () {
 	equal(new Color('red').red(), 255);
@@ -726,12 +725,8 @@ it('Level', function () {
 	equal(Color('grey').level(Color('black')), 'AA');
 });
 
-it('Exceptions', function () {
-	throws(function () {
-		Color('unknow');
-	}, /Unable to parse color from string/);
-
-	throws(function () {
-		Color({});
-	}, /Unable to parse color from object/);
+it('Validity', function () {
+	equal(Color('#424242').isValid(), true);
+	equal(Color('unknow').isValid(), false);
+	equal(Color({}).isValid(), false);
 });


### PR DESCRIPTION
In order to remove this [`try...catch`](https://github.com/chartjs/Chart.js/blob/2d2f475a7a5a48f9d623de88df9314aee0d5f059/src/core/core.element.js#L69).

Basic benchmark: 25000 iterations, 10 times
```
generate_invalid_colors_try_catch (10) total: 3525.405ms average: 352.5405ms
generate_valid_colors_try_catch (10) total: 675.945ms average: 67.5945ms
generate_invalid_colors_flag (10) total: 992.15ms average: 99.215ms
generate_valid_colors_flag (10) total: 663ms average: 66.3ms
```